### PR TITLE
Update sqanti Dockerfile to include newer version of gmap

### DIFF
--- a/sqanti/1.2/Dockerfile
+++ b/sqanti/1.2/Dockerfile
@@ -3,7 +3,7 @@ FROM r-base:3.5.1
 
 ##### METADATA #####
 LABEL base.image="r-base:3.5.1"
-LABEL version="2"
+LABEL version="3"
 LABEL software="sqanti"
 LABEL software.version="1.2"
 LABEL software.description="SQANTI: Structural and Quality Annotation of Novel Transcript Isoforms"
@@ -27,14 +27,14 @@ RUN apt-get update \
   && apt-get install -y tzdata \
   && ln -fs /usr/share/zoneinfo/Europe/Berlin /etc/localtime \
   && dpkg-reconfigure --frontend noninteractive tzdata \
-  && apt-get install -y vim wget curl zlib1g-dev git software-properties-common libcurl4-gnutls-dev libxml2-dev libssl-dev apt-transport-https libmariadb-client-lgpl-dev g++ libbz2-dev perl libgit2-dev \
+  && apt-get install -y vim wget curl zlib1g-dev git software-properties-common libcurl4-gnutls-dev libxml2-dev apt-transport-https libmariadb-client-lgpl-dev g++ libbz2-dev perl libgit2-dev libssl1.1=1.1.1-1 libssl-dev=1.1.1-1 \
   && apt-get install -y python-pip python-dev build-essential \
   && pip install Pysam==0.15 \
   && pip install psutil==5.4.7
 
 # isntall gmap/gsnap
 RUN cd /tmp \
-  && wget http://research-pub.gene.com/gmap/src/gmap-gsnap-2018-05-11.tar.gz \
+  && wget http://research-pub.gene.com/gmap/src/gmap-gsnap-2018-07-04.tar.gz \
   && tar xzf gmap-gsnap-*.tar.gz \
   && cd /tmp/gmap-* \
   && ./configure --prefix=/usr/local --with-simd-level=sse42 \


### PR DESCRIPTION
Fixed problem with libssl library. Updated gmap version to 2018-07-04. The previous version had problems with the CIGAR string. Some read (from Oxford Nanopore) lengths were different from their CIGAR string length.