### PR TITLE
Rmats

### DIFF
--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-slim
 
 ##### METADATA #####
 LABEL base.image="python:2.7-slim"
-LABEL version="1"
+LABEL version="2"
 LABEL software="rmats"
 LABEL software.version="4.0.2"
 LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
@@ -37,8 +37,8 @@ RUN apt-get update -y \
   && rm download
   
 # quick fix
-RUN cd /usr/lib/x86_64-linux-gnu/ \
-  && ln libgsl.so libgsl.so.0 \
+RUN cd /usr/lib/x86_64-linux-gnu \
+  && ln -s libgsl.so libgsl.so.0 \
   && cd $HOME
 
 #  && apt-get autoremove -y && apt-get clean \

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -4,7 +4,7 @@ FROM continuumio/miniconda:4.5.12
 
 ##### METADATA #####
 LABEL base.image="continuumio/miniconda:4.5.12"
-LABEL version="1"
+LABEL version="2"
 LABEL software="rmats"
 LABEL software.version="4.0.2"
 LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
@@ -24,4 +24,4 @@ ENV SOFTWARE_VERSION 4.0.2
 
 ##### INSTALL #####
 RUN apt-get update -y \
-  && conda install -c bioconda rmats=4.0.2
+  && conda install -c bioconda rmats=4.0.2 rmats2sashimiplot=2.0.3

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -22,11 +22,24 @@ LABEL maintainer.license="https://spdx.org/licenses/Apache-2.0"
 ENV SOFTWARE_VERSION 4.0.2
 
 RUN apt-get update -y \
-  && apt-get install -y wget libblas-dev liblapack-dev libgsl2 gfortran \
-  && pip install numpy \
+  && apt-get install -y wget libblas-dev liblapack-dev libgsl2 libgsl-dev gfortran gcc make \
+  && pip2 install numpy \
   && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.4.0.2.tgz/download \
   && tar -xzf download \
-  && chmod + /rMATS.4.0.2/rMATS-turbo-Linux-UCS4/rmats.py
+  && chmod + /rMATS.4.0.2/rMATS-turbo-Linux-UCS4/rmats.py \
+  && rm download \
+  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.4.0.1.tgz/download \
+  && tar -xzf download \
+  && chmod + /rMATS.4.0.1/rMATS-turbo-Linux-UCS4/rmats.py \
+  && rm download \
+  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/testData.tgz/download \
+  && tar -xzf download \
+  && rm download
+  
+# quick fix
+RUN cd /usr/lib/x86_64-linux-gnu/ \
+  && ln libgsl.so libgsl.so.0 \
+  && cd $HOME
 
 #  && apt-get autoremove -y && apt-get clean \
 #  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -1,0 +1,27 @@
+##### BASE IMAGE #####
+
+FROM continuumio/miniconda:4.5.12
+
+##### METADATA #####
+LABEL base.image="continuumio/miniconda:4.5.12"
+LABEL version="1"
+LABEL software="rmats"
+LABEL software.version="4.0.2"
+LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
+LABEL software.website="http://rnaseq-mats.sourceforge.net/"
+LABEL software.documentation="http://rnaseq-mats.sourceforge.net/user_guide.htm"
+LABEL software.license=""
+LABEL software.tags="Genomics,Transcriptomics"
+LABEL maintainer="foivos.gypas@unibas.ch"
+LABEL maintainer.organisation="Biozentrum, University of Basel"
+LABEL maintainer.location="Klingelbergstrasse 50/70, CH-4056 Basel, Switzerland"
+LABEL maintainer.lab="Zavolan Lab"
+LABEL maintainer.license="https://spdx.org/licenses/Apache-2.0"
+
+##### VARIABLES #####
+# Use variables for convenient updates/re-usability
+ENV SOFTWARE_VERSION 4.0.2
+
+##### INSTALL #####
+RUN apt-get update -y \
+  && conda install -c bioconda rmats=4.0.2

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -1,10 +1,9 @@
 ##### BASE IMAGE #####
-
-FROM continuumio/miniconda:4.5.12
+FROM python:2.7-slim
 
 ##### METADATA #####
-LABEL base.image="continuumio/miniconda:4.5.12"
-LABEL version="2"
+LABEL base.image="python:2.7-slim"
+LABEL version="1"
 LABEL software="rmats"
 LABEL software.version="4.0.2"
 LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
@@ -22,6 +21,15 @@ LABEL maintainer.license="https://spdx.org/licenses/Apache-2.0"
 # Use variables for convenient updates/re-usability
 ENV SOFTWARE_VERSION 4.0.2
 
-##### INSTALL #####
 RUN apt-get update -y \
-  && conda install -c bioconda rmats=4.0.2 rmats2sashimiplot=2.0.3
+  && apt-get install -y wget libblas-dev liblapack-dev libgsl2 gfortran \
+  && pip install numpy \
+  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.4.0.2.tgz/download \
+  && tar -xzf download \
+  && chmod + /rMATS.4.0.2/rMATS-turbo-Linux-UCS4/rmats.py
+
+#  && apt-get autoremove -y && apt-get clean \
+#  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+#  && pip install --no-cache-dir numpy pandas
+#
+#COPY *.py /usr/bin/

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-slim
 
 ##### METADATA #####
 LABEL base.image="python:2.7-slim"
-LABEL version="2"
+LABEL version="3"
 LABEL software="rmats"
 LABEL software.version="4.0.2"
 LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
@@ -24,25 +24,14 @@ ENV SOFTWARE_VERSION 4.0.2
 RUN apt-get update -y \
   && apt-get install -y wget libblas-dev liblapack-dev libgsl2 libgsl-dev gfortran gcc make \
   && pip2 install numpy \
-  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.4.0.2.tgz/download \
+  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.${SOFTWARE_VERSION}.tgz/download \
   && tar -xzf download \
-  && chmod + /rMATS.4.0.2/rMATS-turbo-Linux-UCS4/rmats.py \
+  && chmod + /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS4/rmats.py \
+  && chmod + /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS2/rmats.py \
   && rm download \
-  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.4.0.1.tgz/download \
-  && tar -xzf download \
-  && chmod + /rMATS.4.0.1/rMATS-turbo-Linux-UCS4/rmats.py \
-  && rm download \
-  && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/testData.tgz/download \
-  && tar -xzf download \
-  && rm download
-  
-# quick fix
-RUN cd /usr/lib/x86_64-linux-gnu \
+  && cd /usr/lib/x86_64-linux-gnu \
   && ln -s libgsl.so libgsl.so.0 \
-  && cd $HOME
-
-#  && apt-get autoremove -y && apt-get clean \
-#  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-#  && pip install --no-cache-dir numpy pandas
-#
-#COPY *.py /usr/bin/
+  && cd $HOME \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-slim
 
 ##### METADATA #####
 LABEL base.image="python:2.7-slim"
-LABEL version="3"
+LABEL version="4"
 LABEL software="rmats"
 LABEL software.version="4.0.2"
 LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
@@ -26,12 +26,13 @@ RUN apt-get update -y \
   && pip2 install numpy \
   && wget https://sourceforge.net/projects/rnaseq-mats/files/MATS/rMATS.${SOFTWARE_VERSION}.tgz/download \
   && tar -xzf download \
-  && chmod + /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS4/rmats.py \
-  && chmod + /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS2/rmats.py \
+  && chmod +x /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS4/rmats.py \
+  && chmod +x /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS2/rmats.py \
   && rm download \
   && cd /usr/lib/x86_64-linux-gnu \
   && ln -s libgsl.so libgsl.so.0 \
   && cd $HOME \
+  && ln -s /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS4/rmats.py /usr/bin/rmats.py \
   && apt-get autoremove -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/rMATS/4.0.2/Dockerfile
+++ b/rMATS/4.0.2/Dockerfile
@@ -3,7 +3,7 @@ FROM python:2.7-slim
 
 ##### METADATA #####
 LABEL base.image="python:2.7-slim"
-LABEL version="4"
+LABEL version="5"
 LABEL software="rmats"
 LABEL software.version="4.0.2"
 LABEL software.description="MATS is a computational tool to detect differential alternative splicing events from RNA-Seq data."
@@ -32,7 +32,6 @@ RUN apt-get update -y \
   && cd /usr/lib/x86_64-linux-gnu \
   && ln -s libgsl.so libgsl.so.0 \
   && cd $HOME \
-  && ln -s /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS4/rmats.py /usr/bin/rmats.py \
   && apt-get autoremove -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Rmats is working fine, but users have to specify  the path 

`python /rMATS.${SOFTWARE_VERSION}/rMATS-turbo-Linux-UCS4/rmats.py`

Will merge for the moment and if there is some update in the following issue https://github.com/bioconda/bioconda-recipes/issues/12782 we might consider to change it to install it via bioconda. 

