### PR TITLE
implement continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,46 @@
+os:
+- linux
+dist: bionic
+language: minimal
+
+services:
+- docker
+
+stages:
+# Execute upon PR or push to open PR
+- name: build_image
+  if: type = pull_request
+# Execute only upon merge into master
+- name: push_image
+  if: type = push AND branch = master
+
+jobs:
+  include:
+  - stage: build_image
+    name: Build Docker image
+    script:
+    - |
+      git diff --name-only "$TRAVIS_COMMIT_RANGE" | \
+      grep "Dockerfile" | \
+      while read -r file ; do
+        echo "Building image for Dockerfile '$file'..."
+        docker build $(dirname "$file")
+      done
+  - stage: push_image
+    name: Build image and push to Docker Hub
+    script:
+    - |
+      git diff --name-only "$TRAVIS_COMMIT_RANGE" | \
+      grep "Dockerfile" | \
+      while read -r file ; do
+        # Extract tool name and version and sanitize according to Docker rules
+        tool_name=$(dirname $(dirname "$file") | tr A-Z a-z | sed 's/[^a-z\-\_]//g')
+        version=$(basename $(dirname "$file") | sed -e 's/[^a-zA-Z0-9\_\.\-]//g' -e 's/^[\.\-]//')
+        remote="${DOCKER_ORGANIZATION}/${tool_name}:${version}"
+        echo "Building image for Dockerfile '$file'..."
+        docker build -t "$remote" $(dirname $file)
+        echo "Pushing image to '$remote'..."
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        docker push "$remote"
+      done
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
+[![Build 
+Status](https://travis-ci.com/zavolanlab/Dockerfiles.svg?branch=master)](https://travis-ci.com/zavolanlab/Dockerfiles)
+
 # Dockerfiles
+
 Dockerfile repository of the Zavolan Lab


### PR DESCRIPTION
- Travis CI configuration file was added
- upon submission of a PR, every `Dockerfile` that was added or modified for the PR is built; the CI pipeline will only report a passing state if all images could be successfully built (or if no `Dockerfile` was added/modified for the PR)
- upon merging a PR, every `Dockerfile` that was added or modified for the PR is built and, if successful, pushed to [`zavolab` Docker Hub organization](https://hub.docker.com/orgs/zavolab); the CI pipeline will only report a passing state if all images could be successfully built **and** pushed (or if no `Dockerfile` was added/modified for the PR)
- pushing commits to a feature branch will only trigger the CI pipeline if an open PR for the feature branch exists
- **adherence to the directory naming scheme (`<root_dir>/<tool_name>/<version>`/Dockerfile) is crucially** important, as Docker Hub repo name and tag name are derived from the tool name and version directory, respectively; this is currently **not** checked by the logic inside the Travis CI config
- a Travis status badge for branch `master` was added to `README.md`
- branch protection rules for branch `master` were adjusted such that merging PRs is only possible if the Travis CI pipeline completes successfully 

Closes #35 