### PR TITLE
feat: add 1.1 for MAPP-Python with updated HTSeq

### DIFF
--- a/MAPP_base_python/1.1/Dockerfile
+++ b/MAPP_base_python/1.1/Dockerfile
@@ -1,0 +1,40 @@
+##### BASE IMAGE #####
+FROM continuumio/miniconda3:4.7.10
+
+##### METADATA #####
+LABEL base.image="continuumio/miniconda3:4.7.10"
+LABEL version="1.0"
+LABEL software=""
+LABEL software.version=""
+LABEL software.description="Python libraries for data analysis"
+LABEL software.website=""
+LABEL software.documentation=""
+LABEL software.license=""
+LABEL software.tags="Data Analysis"
+LABEL maintainer="maciej.bak@unibas.ch"
+LABEL maintainer.organisation="Biozentrum, University of Basel"
+LABEL maintainer.location="Klingelbergstrasse 50/70, CH-4056 Basel, Switzerland"
+LABEL maintainer.lab="Zavolan Lab"
+LABEL maintainer.license=""
+
+##### VARIABLES #####
+# Use variables for convenient updates/re-usability
+
+# COPY THE YAML & INSTALL SOFTWARE WITH CONDA
+COPY environment.yaml .
+RUN conda env update --name base --file environment.yaml
+RUN conda clean --all
+
+# VARIABLES
+ARG WORKDIR="/home/container/"
+ARG USER="USER"
+ARG GROUP="GROUP"
+ENV PATH="${WORKDIR}:${PATH}"
+
+# CREATE USER
+RUN groupadd -r ${GROUP} && useradd --no-log-init -r -g ${GROUP} ${USER}
+
+# SET ENVIRONMENT
+WORKDIR ${WORKDIR}
+RUN chown -R ${USER}:${GROUP} ${WORKDIR} && chmod 700 ${WORKDIR}
+USER ${USER}

--- a/MAPP_base_python/1.1/environment.yaml
+++ b/MAPP_base_python/1.1/environment.yaml
@@ -1,0 +1,33 @@
+###############################################################################
+#
+#   Main software to be installed in the environment
+#
+#   AUTHOR: Maciej_Bak
+#   AFFILIATION: Biozentrum_University_of_Basel
+#   AFFILIATION: Swiss_Institute_of_Bioinformatics
+#   CONTACT: maciej.bak@unibas.ch
+#   CREATED: 20-01-2020
+#   LICENSE: GPL
+#
+###############################################################################
+---
+
+channels:
+  - bioconda
+  - conda-forge
+
+dependencies:
+  - python=3.6.3
+  - numpy=1.15.2
+  - pandas=0.21.0
+  - pyyaml=3.12
+  - scipy=1.0.0
+  - matplotlib=3.1.0
+  - seaborn=0.8.1
+  - statsmodels=0.10.2
+  - pybedtools=0.7.10
+  - htseq=0.12.4
+  - pymongo=3.2.2
+  - jinja2=2.10
+
+...


### PR DESCRIPTION
It turns out I needed to bump-up `HTSeq` version in my all-Python general env. for _MAPP_.
Fortunately the changes were contained within few minor version updates in the yaml file (therefore `1.1` here, after `1.0`).

Priority: High; quite urgent for me to have the container at _Dockerhub_ asap since it is blocking my analyses.

---

CC: @fgypas @uniqueg 